### PR TITLE
Avoid using libxml disable entity loader in newer version of libxml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-vendor
+/vendor
+/composer.lock

--- a/src/XmlValidator.php
+++ b/src/XmlValidator.php
@@ -25,13 +25,17 @@ class XmlValidator
         }
 
         $internalErrors = libxml_use_internal_errors(true);
-        $disableEntities = libxml_disable_entity_loader(true);
+        if (\LIBXML_VERSION < 20900) {
+            $disableEntities = libxml_disable_entity_loader(true);
+        }
         libxml_clear_errors();
 
         $dom = new \DOMDocument();
         $dom->validateOnParse = true;
         if (!$dom->loadXML($xml, LIBXML_NONET | (defined('LIBXML_COMPACT') ? LIBXML_COMPACT : 0))) {
-            libxml_disable_entity_loader($disableEntities);
+            if (\LIBXML_VERSION < 20900) {
+                libxml_disable_entity_loader($disableEntities);
+            }
             $this->errors = $this->getXmlErrors($internalErrors);
             return false;
         }
@@ -39,7 +43,9 @@ class XmlValidator
         $dom->normalizeDocument();
 
         libxml_use_internal_errors($internalErrors);
-        libxml_disable_entity_loader($disableEntities);
+        if (\LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader($disableEntities);
+        }
 
         foreach ($dom->childNodes as $child) {
             if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {


### PR DESCRIPTION
Similar how Symfony's XmlUtils works, the function `libxml_disable_entity_loader` should only be used on libxml version lower than 20900.

No breaking changes.